### PR TITLE
Bump version to 1.0.5 and update changelog with hotfix for missing class in plugin updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ If you are logged in as a super admin, this plugin allows you to switch to a reg
 
 ## Changelog
 
+### 1.0.5
+- Hotfix: Add missing class for plugin updater.
+
 ### 1.0.4
 - Add plugin updater.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "additional-javascript",
-	"version": "1.1.1",
+	"name": "super-admin-switch-to-admin",
+	"version": "1.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "additional-javascript",
-			"version": "1.1.1",
+			"name": "super-admin-switch-to-admin",
+			"version": "1.0.5",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-switch-to-admin",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Switch to the admin user for Super Admins.",
 	"keywords": [
 		"wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Super Admin Switch to Admin ===
 Contributors: PerS
 Tags: super admin, multisite, admin, switch
-Requires at least: 6.0
-Tested up to: 6.3
-Requires PHP: 7.3 
-Stable tag: 1.0.4
+Requires at least: 6.5
+Tested up to: 6.8
+Requires PHP: 8.2
+Stable tag: 1.0.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,6 +32,9 @@ It lists all admins for the current site, except for the super admin., and creat
 1. The plugin in action.
 
 == Changelog ==
+
+= 1.0.5 =
+* Hotfix: Add missing class for plugin updater.
 
 = 1.0.4 =
 * Add plugin updater.

--- a/super-admin-switch-to-admin.php
+++ b/super-admin-switch-to-admin.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-switch-to-admin
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-switch-to-admin
  * Description: If you are logged in as a super admin, allows you to switch to a regular admin account on the current site.
- * Version:     1.0.4
+ * Version:     1.0.5
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Network:     true
@@ -37,9 +37,9 @@ require_once SWITCH_TO_ADMIN_PATH . 'vendor/autoload.php';
 /**
  * Load the plugin updater class.
  */
-require_once dirname( __FILE__ ) . '/class-additional-javascript-updater.php';
+require_once dirname( __FILE__ ) . '/class-switch-to-admin-updater.php';
 // Initialize the updater.
-$additional_javascript_updater = new Additional_JavaScript_Updater();
+$switch_to_admin_updater = new Switch_To_Admin_Updater();
 
 /**
  * Class SuperAdminSwitchToAdmin


### PR DESCRIPTION
This pull request includes updates to version 1.0.5 of the `super-admin-switch-to-admin` plugin. The changes primarily address a hotfix for the plugin updater and update compatibility requirements. Below is a summary of the most important changes:

### Hotfix for plugin updater:

* [`super-admin-switch-to-admin.php`](diffhunk://#diff-0fb19e39afd872906c2247b78b116beebd6bf1818a4c47b911e8e2ecef2e18e1L40-R42): Replaced the updater class `Additional_JavaScript_Updater` with the correct `Switch_To_Admin_Updater` class and updated the corresponding `require_once` path.
* `README.md` and `readme.txt`: Added a changelog entry for version 1.0.5, noting the hotfix for the missing class in the plugin updater. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R35) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R36-R38)

### Version updates:

* `package.json` and `super-admin-switch-to-admin.php`: Updated the plugin version to 1.0.5. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-0fb19e39afd872906c2247b78b116beebd6bf1818a4c47b911e8e2ecef2e18e1L15-R15)

### Compatibility updates:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L4-R7): Updated the compatibility requirements to reflect the latest tested WordPress version (6.8), minimum required WordPress version (6.5), and PHP version (8.2).