### PR TITLE
Bump version to 1.0.8, update changelog, and fix file path for GitHub…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ If you are logged in as a super admin, this plugin allows you to switch to a reg
 
 ## Changelog
 
+### 1.0.8
+* Bugfix
+
 ### 1.0.7
 - Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-switch-to-admin",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "Switch to the admin user for Super Admins.",
 	"keywords": [
 		"wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: super admin, multisite, admin, switch
 Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,11 @@ It lists all admins for the current site, except for the super admin., and creat
 
 
 == Changelog ==
+
+= 1.0.8 =
+* Bugfix
+
+
 = 1.0.7 =
 * Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
 

--- a/super-admin-switch-to-admin.php
+++ b/super-admin-switch-to-admin.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-switch-to-admin
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-switch-to-admin
  * Description: If you are logged in as a super admin, allows you to switch to a regular admin account on the current site.
- * Version:     1.0.7
+ * Version:     1.0.8
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Network:     true
@@ -37,7 +37,7 @@ require_once SWITCH_TO_ADMIN_PATH . 'vendor/autoload.php';
 
 // Include plugin updater
 if ( ! class_exists( 'Soderlind\WordPress\GitHub_Plugin_Updater' ) ) {
-	require_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/class-github-plugin-updater.php';
+	require_once SWITCH_TO_ADMIN_PATH . 'includes/class-github-plugin-updater.php';
 }
 
 // Initialize the plugin updater.


### PR DESCRIPTION
This pull request updates the plugin to version 1.0.8, introduces a bugfix, and corrects the file path for the GitHub plugin updater. Below is a summary of the most important changes:

### Version Update and Changelog
* Updated the plugin version from 1.0.7 to 1.0.8 in `package.json`, `super-admin-switch-to-admin.php`, and `readme.txt`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-0fb19e39afd872906c2247b78b116beebd6bf1818a4c47b911e8e2ecef2e18e1L15-R15) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Added a changelog entry for version 1.0.8, indicating a bugfix, in `README.md` and `readme.txt`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R35) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R38-R42)

### Code Fix
* Updated the file path for the GitHub plugin updater in `super-admin-switch-to-admin.php` to use the correct constant `SWITCH_TO_ADMIN_PATH` instead of `MULTISITE_EXPORTER_PLUGIN_DIR`.