### PR TITLE
Require User Switching plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+## Changelog
+
+### 1.0.10
+* Force, via plugin header, the required User Switching plugin.
+
+### 1.0.9
+* Another bugfix. Note to self, test better before releasing.
+
+### 1.0.8
+* Bugfix
+
+### 1.0.7
+- Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
+
+
+### 1.0.6
+- Update installation instructions.
+
+### 1.0.5
+- Hotfix: Add missing class for plugin updater.
+
+### 1.0.4
+- Add plugin updater.
+
+### 1.0.3
+
+- Exclude all super admins from the list of admins.
+
+### 1.0.2
+
+- Add Norwegian translation.
+
+### 1.0.1
+
+- Add a screenshot.
+
+### 1.0.0
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -28,43 +28,6 @@ If you are logged in as a super admin, this plugin allows you to switch to a reg
    * Plugin updates are handled automatically via GitHub. No need to manually download and install updates.
 
 
-## Changelog
-
-### 1.0.9
-* Another bugfix. Note to self, test better before releasing.
-
-### 1.0.8
-* Bugfix
-
-### 1.0.7
-- Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
-
-
-### 1.0.6
-- Update installation instructions.
-
-### 1.0.5
-- Hotfix: Add missing class for plugin updater.
-
-### 1.0.4
-- Add plugin updater.
-
-### 1.0.3
-
-- Exclude all super admins from the list of admins.
-
-### 1.0.2
-
-- Add Norwegian translation.
-
-### 1.0.1
-
-- Add a screenshot.
-
-### 1.0.0
-
-- Initial release
-
 ## Copyright and License
 
 Super Admin Switch to Admin is copyright 2023 Per Soderlind

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-switch-to-admin",
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"description": "Switch to the admin user for Super Admins.",
 	"keywords": [
 		"wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: super admin, multisite, admin, switch
 Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.0.9
+Stable tag: 1.0.10
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,9 @@ It lists all admins for the current site, except for the super admin., and creat
 
 
 == Changelog ==
+
+= 1.0.10 =
+* Force, via plugin header, the required User Switching plugin.
 
 = 1.0.9 =
 * Another bugfix. Note to self, test better before releasing.

--- a/super-admin-switch-to-admin.php
+++ b/super-admin-switch-to-admin.php
@@ -12,7 +12,8 @@
  * Plugin URI: https://github.com/soderlind/super-admin-switch-to-admin
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-switch-to-admin
  * Description: If you are logged in as a super admin, allows you to switch to a regular admin account on the current site.
- * Version:     1.0.9
+ * Requires Plugins: user-switching
+ * Version:     1.0.10
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Network:     true


### PR DESCRIPTION
This pull request updates the plugin to version 1.0.10 and introduces a requirement for the User Switching plugin via the plugin header. It also updates changelogs and version references across documentation and metadata files to reflect the new release.

**Plugin requirements and metadata:**

* Added `Requires Plugins: user-switching` to the plugin header in `super-admin-switch-to-admin.php`, enforcing the requirement for the User Switching plugin.
* Bumped version number to 1.0.10 in `super-admin-switch-to-admin.php`, `package.json`, and `readme.txt`. [[1]](diffhunk://#diff-0fb19e39afd872906c2247b78b116beebd6bf1818a4c47b911e8e2ecef2e18e1L15-R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)

**Documentation updates:**

* Updated the changelog in `CHANGELOG.md` and `readme.txt` to document the new requirement and release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R39) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R39-R41)
* Removed the redundant changelog section from `README.md` to avoid duplication.